### PR TITLE
Printer ik solver refactor

### DIFF
--- a/ROS_ws/src/printer/printer_ik_solver/src/printer_ik_solver.cpp
+++ b/ROS_ws/src/printer/printer_ik_solver/src/printer_ik_solver.cpp
@@ -20,7 +20,7 @@ PrinterIKSolver::PrinterIKSolver(const ros::Publisher& status_pub) :
 
 }
 
-/// \brief Calculate inverse kinematics for sPrinter robot lens.
+/// \brief Calculate inverse kinematics for sPrinter robot lens with enabled approximate solutions.
 /// \param desired_pose Pose in base_link frame.
 /// \param joint_values_ik Vector of joint values.
 /// \return

--- a/ROS_ws/src/printer/printer_ik_solver/src/printer_ik_solver.cpp
+++ b/ROS_ws/src/printer/printer_ik_solver/src/printer_ik_solver.cpp
@@ -27,7 +27,11 @@ PrinterIKSolver::PrinterIKSolver(const ros::Publisher& status_pub) :
 bool PrinterIKSolver::calculateIK(const geometry_msgs::PoseStamped& desired_pose, std::vector<double>& joint_values_ik)
 {
     robot_state_->setToDefaultValues();
-    bool ik_found = robot_state_->setFromIK(joint_model_group_, desired_pose.pose, 0.1);
+    // we may need to do approximate IK
+    kinematics::KinematicsQueryOptions o;
+    o.return_approximate_solution = true;
+
+    bool ik_found = robot_state_->setFromIK(joint_model_group_, desired_pose.pose, 0.1,  moveit::core::GroupStateValidityCallbackFn(), o);
 
     if (ik_found)
     {


### PR DESCRIPTION
Added approximation as constraint for IK solver. 

Now we are **able to calculate IK** as before, but the **result is more likely returned if reachable** by end effector. There is no more need to set the exact pose for end effector.